### PR TITLE
sgw: use UDP source address for local tunnel creation

### DIFF
--- a/src/sgw/sgw_handlers.c
+++ b/src/sgw/sgw_handlers.c
@@ -140,8 +140,7 @@ sgw_handle_create_session_request (
     s_plus_p_gw_eps_bearer_ctxt_info_p->sgw_eps_bearer_context_information.mme_teid_S11 = session_req_pP->sender_fteid_for_cp.teid;
     s_plus_p_gw_eps_bearer_ctxt_info_p->sgw_eps_bearer_context_information.s_gw_teid_S11_S4 = new_endpoint_p->local_teid;
     s_plus_p_gw_eps_bearer_ctxt_info_p->sgw_eps_bearer_context_information.trxn = session_req_pP->trxn;
-    //s_plus_p_gw_eps_bearer_ctxt_info_p->sgw_eps_bearer_context_information.mme_int_ip_address_S11 = session_req_pP->peer_ip;
-    FTEID_T_2_IP_ADDRESS_T ((&session_req_pP->sender_fteid_for_cp), (&s_plus_p_gw_eps_bearer_ctxt_info_p->sgw_eps_bearer_context_information.mme_ip_address_S11));
+    s_plus_p_gw_eps_bearer_ctxt_info_p->sgw_eps_bearer_context_information.mme_ip_address_S11.address.ipv4_address = session_req_pP->peer_ip;
     //--------------------------------------
     // PDN connection
     //--------------------------------------


### PR DESCRIPTION
nwGtpv2cHandleInitialReq() uses UDP source address as part of a key to
lookup NwGtpv2cTunnelMap when the message's TEID is not 0
(e.g. Modify Bearer Request).

However, when we get CreateSessionRequest from MME, we were using the MME
IP address in F-TEID as a key to insert a new tunnel in NwGtpv2cTunnelMap.

When MME is behind NAT, the UDP source address and the address in F-TEID
is different, so ModifyBearerRequest handling fails with the message,

"Request message received on non-existent teid 0x1 from peer 172.17.0.1 received! Discarding."

This commit fixes to use UDP source address for local tunnel creation
and solves the issue.

Signed-off-by: Wataru Ishida <ishida.wataru@lab.ntt.co.jp>