### PR TITLE
Fixed the MME crash at snprintf

### DIFF
--- a/src/utils/pid_file.c
+++ b/src/utils/pid_file.c
@@ -82,7 +82,7 @@ int lockfile(int fd, int lock_type)
 //------------------------------------------------------------------------------
 bool is_pid_file_lock_success(char const *pid_file_name)
 {
-  char       pid_dec[32] = {0};
+  char       pid_dec[64] = {0};
 
   g_fd_pid_file = open(pid_file_name,
                        O_RDWR | O_CREAT,


### PR DESCRIPTION
The crash was observed at MME bring-up while copying process ID to an array of lesser size