### PR TITLE
Add encoding/decoding of Voice Domain Prefererence IE of TrackingAreaUpdateRequest

### DIFF
--- a/src/nas/emm/msg/TrackingAreaUpdateRequest.c
+++ b/src/nas/emm/msg/TrackingAreaUpdateRequest.c
@@ -264,6 +264,17 @@ decode_tracking_area_update_request (
       tracking_area_update_request->presencemask |= TRACKING_AREA_UPDATE_REQUEST_ADDITIONAL_UPDATE_TYPE_PRESENT;
       break;
 
+    case TRACKING_AREA_UPDATE_REQUEST_VOICE_DOMAIN_PREFERENCE_AND_UE_USAGE_SETTING_IEI:
+      if ((decoded_result = decode_voice_domain_preference_and_ue_usage_setting (&tracking_area_update_request->voicedomainpreferenceandueusagesetting, TRACKING_AREA_UPDATE_REQUEST_VOICE_DOMAIN_PREFERENCE_AND_UE_USAGE_SETTING_IEI, buffer + decoded, len - decoded)) <= 0)
+        return decoded_result;
+
+      decoded += decoded_result;
+      /*
+       * Set corresponding mask to 1 in presencemask
+       */
+      tracking_area_update_request->presencemask |= TRACKING_AREA_UPDATE_REQUEST_VOICE_DOMAIN_PREFERENCE_AND_UE_USAGE_SETTING_PRESENT;
+      break;
+
     case TRACKING_AREA_UPDATE_REQUEST_OLD_GUTI_TYPE_IEI:
       if ((decoded_result = decode_guti_type (&tracking_area_update_request->oldgutitype, TRACKING_AREA_UPDATE_REQUEST_OLD_GUTI_TYPE_IEI, buffer + decoded, len - decoded)) <= 0)
         return decoded_result;
@@ -454,6 +465,15 @@ encode_tracking_area_update_request (
   if ((tracking_area_update_request->presencemask & TRACKING_AREA_UPDATE_REQUEST_ADDITIONAL_UPDATE_TYPE_PRESENT)
       == TRACKING_AREA_UPDATE_REQUEST_ADDITIONAL_UPDATE_TYPE_PRESENT) {
     if ((encode_result = encode_additional_update_type (&tracking_area_update_request->additionalupdatetype, TRACKING_AREA_UPDATE_REQUEST_ADDITIONAL_UPDATE_TYPE_IEI, buffer + encoded, len - encoded)) < 0)
+      // Return in case of error
+      return encode_result;
+    else
+      encoded += encode_result;
+  }
+
+  if ((tracking_area_update_request->presencemask & TRACKING_AREA_UPDATE_REQUEST_VOICE_DOMAIN_PREFERENCE_AND_UE_USAGE_SETTING_PRESENT)
+      == TRACKING_AREA_UPDATE_REQUEST_VOICE_DOMAIN_PREFERENCE_AND_UE_USAGE_SETTING_PRESENT) {
+    if ((encode_result = encode_voice_domain_preference_and_ue_usage_setting (&tracking_area_update_request->voicedomainpreferenceandueusagesetting, TRACKING_AREA_UPDATE_REQUEST_VOICE_DOMAIN_PREFERENCE_AND_UE_USAGE_SETTING_IEI, buffer + encoded, len - encoded)) < 0)
       // Return in case of error
       return encode_result;
     else

--- a/src/nas/emm/msg/TrackingAreaUpdateRequest.h
+++ b/src/nas/emm/msg/TrackingAreaUpdateRequest.h
@@ -64,6 +64,7 @@
     MOBILE_STATION_CLASSMARK_2_MAXIMUM_LENGTH + \
     MOBILE_STATION_CLASSMARK_3_MAXIMUM_LENGTH + \
     SUPPORTED_CODEC_LIST_MAXIMUM_LENGTH + \
+    VOICE_DOMAIN_PREFERENCE_AND_UE_USAGE_SETTING_MAXIMUM_LENGTH + \
     ADDITIONAL_UPDATE_TYPE_MAXIMUM_LENGTH )
 
 /* If an optional value is present and should be encoded, the corresponding
@@ -86,7 +87,8 @@
 # define TRACKING_AREA_UPDATE_REQUEST_MOBILE_STATION_CLASSMARK_3_PRESENT                    (1<<14)
 # define TRACKING_AREA_UPDATE_REQUEST_SUPPORTED_CODECS_PRESENT                              (1<<15)
 # define TRACKING_AREA_UPDATE_REQUEST_ADDITIONAL_UPDATE_TYPE_PRESENT                        (1<<16)
-# define TRACKING_AREA_UPDATE_REQUEST_OLD_GUTI_TYPE_PRESENT                                 (1<<17)
+# define TRACKING_AREA_UPDATE_REQUEST_VOICE_DOMAIN_PREFERENCE_AND_UE_USAGE_SETTING_PRESENT  (1<<17)
+# define TRACKING_AREA_UPDATE_REQUEST_OLD_GUTI_TYPE_PRESENT                                 (1<<18)
 
 typedef enum tracking_area_update_request_iei_tag {
   TRACKING_AREA_UPDATE_REQUEST_NONCURRENT_NATIVE_NAS_KEY_SET_IDENTIFIER_IEI       = 0xB0, /* 0xB0 = 176 */
@@ -106,6 +108,7 @@ typedef enum tracking_area_update_request_iei_tag {
   TRACKING_AREA_UPDATE_REQUEST_MOBILE_STATION_CLASSMARK_3_IEI                     = C_MOBILE_STATION_CLASSMARK_3_IEI,
   TRACKING_AREA_UPDATE_REQUEST_SUPPORTED_CODECS_IEI                               = 0x40, /* 0x40 = 64 */
   TRACKING_AREA_UPDATE_REQUEST_ADDITIONAL_UPDATE_TYPE_IEI                         = 0xF0, /* 0xF0 = 240 */
+  TRACKING_AREA_UPDATE_REQUEST_VOICE_DOMAIN_PREFERENCE_AND_UE_USAGE_SETTING_IEI   = 0x5D, /* 0x5D = 93  */
   TRACKING_AREA_UPDATE_REQUEST_OLD_GUTI_TYPE_IEI                                  = 0xE0, /* 0xE0 = 224 */
 } tracking_area_update_request_iei;
 
@@ -143,6 +146,7 @@ typedef struct tracking_area_update_request_msg_tag {
   mobile_station_classmark3_t              mobilestationclassmark3;
   supported_codec_list_t                   supportedcodecs;
   additional_update_type_t                 additionalupdatetype;
+  voice_domain_preference_and_ue_usage_setting_t   voicedomainpreferenceandueusagesetting;
   guti_type_t                              oldgutitype;
 } tracking_area_update_request_msg;
 


### PR DESCRIPTION
When MME receives TrackingAreaUpdateRequest with this IEI but not aware of it,
MME will reply TrackingAreaUpdateReject message to UE with EMM cause :

  Information element non-existent or not implemented (99).

Add encoding/decoding of Voice Domain Preference And UE Usage Setting IE
for Tracking Area Update Request message to solve it.

ps. At least one Huawei Android phone was found sending TrackingAreaUpdateRequest with this IE.