### PR TITLE
Handle two S1AP messages in one SCTP_DATA_IND

### DIFF
--- a/src/s1ap/s1ap_mme_decoder.c
+++ b/src/s1ap/s1ap_mme_decoder.c
@@ -298,13 +298,14 @@ int
 s1ap_mme_decode_pdu (
   s1ap_message *message,
   const_bstring const raw,
+  int offset,
   MessagesIds *message_id) {
   S1AP_PDU_t                              pdu = {(S1AP_PDU_PR_NOTHING)};
   S1AP_PDU_t                             *pdu_p = &pdu;
   asn_dec_rval_t                          dec_ret = {(RC_OK)};
   DevAssert (raw != NULL);
   memset ((void *)pdu_p, 0, sizeof (S1AP_PDU_t));
-  dec_ret = aper_decode (NULL, &asn_DEF_S1AP_PDU, (void **)&pdu_p, bdata(raw), blength(raw), 0, 0);
+  dec_ret = aper_decode (NULL, &asn_DEF_S1AP_PDU, (void **)&pdu_p, bdataofs(raw, offset), blength(raw) - offset, 0, 0);
 
   if (dec_ret.code != RC_OK) {
     OAILOG_ERROR (LOG_S1AP, "Failed to decode PDU\n");

--- a/src/s1ap/s1ap_mme_decoder.h
+++ b/src/s1ap/s1ap_mme_decoder.h
@@ -27,7 +27,7 @@
 #include "s1ap_common.h"
 #include "s1ap_ies_defs.h"
 
-int s1ap_mme_decode_pdu(s1ap_message *message, const_bstring const raw, MessagesIds *messages_id) __attribute__ ((warn_unused_result));
+int s1ap_mme_decode_pdu(s1ap_message *message, const_bstring const raw, int offset, MessagesIds *messages_id) __attribute__ ((warn_unused_result));
 int s1ap_free_mme_decode_pdu(s1ap_message *message, MessagesIds messages_id);
 
 #endif /* FILE_S1AP_MME_DECODER_SEEN */

--- a/src/utils/mme_default_values.h
+++ b/src/utils/mme_default_values.h
@@ -57,6 +57,7 @@
 #define SCTP_OUT_STREAMS      (32)
 #define SCTP_IN_STREAMS       (32)
 #define SCTP_MAX_ATTEMPTS     (5)
+#define SCTP_DATA_CHUNK_HEADER_SIZE (16)
 
 /*******************************************************************************
  * MME global definitions


### PR DESCRIPTION
Sometimes there are two S1AP messages in different SCTP chunks inside one SCTP_DATA_IND, we have to parse it correctly.