### PR TITLE
Fix for OPC generation when bytes have value <= 0xf: "0" was not prep…

### DIFF
--- a/src/hss_rel14/src/dataaccess.cpp
+++ b/src/hss_rel14/src/dataaccess.cpp
@@ -833,9 +833,9 @@ bool DataAccess::checkOpcKeys( const uint8_t opP[16] )
       ComputeOPc (key_bin, opP, opccalc);
 
       std::stringstream ss;
-      ss << std::hex << std::setfill('0') << std::setw(2);
+      ss << std::hex;
       for(int i(0);i<KEY_LENGTH;++i){
-          ss<< (unsigned int)opccalc[i];
+          ss << std::setfill('0') << std::setw(2) << (unsigned int)opccalc[i];
       }
       std::string newopc = ss.str();
       std::cout << "NEW OPC :" << newopc << std::endl;


### PR DESCRIPTION
DataAccess::checkOpcKeys() computes a wrong OPC when some bytes have values <= 0xf. Then, a "0" is not prepended to the text value except for byte 0.

This pull request fixes the issue (also reported here: https://github.com/OPENAIRINTERFACE/openair-cn/issues/70) by making sure that the "0" is always prepended when necessary.