### PR TITLE
fixes for s10 handover  regarding removal of procedures

### DIFF
--- a/src/mme_app/mme_app_bearer.c
+++ b/src/mme_app/mme_app_bearer.c
@@ -4651,6 +4651,10 @@ mme_app_handle_handover_failure (
        ue_context->privates.fields.local_mme_teid_s10, ue_context->privates.mme_ue_s1ap_id, ue_context->privates.mme_ue_s1ap_id);
  }
 
+ // todo: lock UE context
+ ue_context->privates.s1_ue_context_release_cause == S1AP_HANDOVER_FAILED;
+ // todo: unlock ue context
+
  /**
   * UE is in UE_UNREGISTERED state. Assuming inter-MME S1AP Handover was triggered.
   * Sending FW_RELOCATION_RESPONSE with error code and implicit detach.

--- a/src/mme_app/mme_app_context.c
+++ b/src/mme_app/mme_app_context.c
@@ -164,15 +164,6 @@ ue_context_t * get_new_ue_context() {
   OAILOG_FUNC_RETURN (LOG_MME_APP, ue_context);
 }
 
-void test_ue_context_extablishment(){
-	ue_context_t *ue_context_1 = get_new_ue_context();
-	ue_context_t *ue_context_2 = get_new_ue_context();
-	ue_context_t *ue_context_3 = get_new_ue_context();
-
-	mme_remove_ue_context(&mme_app_desc.mme_ue_contexts, ue_context_1);
-	mme_remove_ue_context(&mme_app_desc.mme_ue_contexts, ue_context_2);
-	mme_remove_ue_context(&mme_app_desc.mme_ue_contexts, ue_context_3);
-}
 //------------------------------------------------------------------------------
 ue_context_t                           *
 mme_ue_context_exists_enb_ue_s1ap_id (
@@ -2898,7 +2889,9 @@ static void clear_ue_context(ue_context_t * ue_context) {
 
 	/** Will remove the S10 procedures and tunnel endpoints. */
 	if (ue_context->s10_procedures) {
+		ue_context->privates.s1_ue_context_release_cause = S1AP_HANDOVER_CANCELLED;
 		mme_app_delete_s10_procedure_mme_handover(ue_context); // todo: generic s10 function
+		ue_context->privates.s1_ue_context_release_cause = S1AP_INVALID_CAUSE;
 	}
 
 	mme_ue_s1ap_id_t ue_id = ue_context->privates.mme_ue_s1ap_id;

--- a/src/mme_app/mme_app_ue_context.h
+++ b/src/mme_app/mme_app_ue_context.h
@@ -354,8 +354,6 @@ void mme_ue_context_dump_coll_keys(void);
  **/
 ue_context_t * get_new_ue_context();
 
-void test_ue_context_extablishment();
-
 /** \brief Remove a UE context of the tree of known UEs.
  * \param ue_context_p The UE context to remove
  **/

--- a/src/nas/emm/Attach.c
+++ b/src/nas/emm/Attach.c
@@ -419,6 +419,8 @@ int emm_proc_attach_request (
       // todo: this probably will not work, we need to update the enb_ue_s1ap_id of the old UE context to continue to work with it!
       //              unlock_ue_contexts(ue_context);
       //             unlock_ue_contexts(imsi_ue_mm_ctx);
+      emm_init_context(new_emm_ue_ctx);
+      DevAssert(RETURNok == emm_data_context_add (&_emm_data, new_emm_ue_ctx));
       OAILOG_FUNC_RETURN (LOG_NAS_EMM, RETURNok);
     } else{
     	new_emm_ue_ctx = (*duplicate_emm_ue_ctx_pP);

--- a/src/nas/emm/TrackingAreaUpdate.c
+++ b/src/nas/emm/TrackingAreaUpdate.c
@@ -352,6 +352,8 @@ int emm_proc_tracking_area_update_request (
         // todo: this probably will not work, we need to update the enb_ue_s1ap_id of the old UE context to continue to work with it!
         //              unlock_ue_contexts(ue_context);
         //             unlock_ue_contexts(imsi_ue_mm_ctx);
+        emm_init_context(new_emm_ue_context);
+        DevAssert(RETURNok == emm_data_context_add (&_emm_data, new_emm_ue_context));
         OAILOG_FUNC_RETURN (LOG_NAS_EMM, RETURNok);
     } else{
     	 new_emm_ue_context = (*duplicate_emm_ue_ctx_pP);
@@ -1714,7 +1716,7 @@ static int _emm_tau_retry_procedure(mme_ue_s1ap_id_t ue_id){
   int                                      rc = RETURNerror;
   emm_data_context_t                     * emm_context                 = emm_data_context_get(&_emm_data, ue_id);
   if(!emm_context){
-	  OAILOG_ERROR(LOG_NAS_EMM, "EMM-PROC  - Attach retry: no EMM context for UE " MME_UE_S1AP_ID_FMT". Triggering implicit detach. \n", ue_id);
+	  OAILOG_ERROR(LOG_NAS_EMM, "EMM-PROC  - TAU retry: no EMM context for UE " MME_UE_S1AP_ID_FMT". Triggering implicit detach. \n", ue_id);
 	  rc = _emm_tracking_area_update_reject(ue_id, EMM_CAUSE_ILLEGAL_UE);
 	  OAILOG_FUNC_RETURN (LOG_NAS_EMM, rc);
   }

--- a/src/nas/nas_itti_messaging.c
+++ b/src/nas/nas_itti_messaging.c
@@ -559,6 +559,11 @@ void nas_itti_establish_cnf(
 
   emm_ctx = emm_data_context_get(&_emm_data, ue_idP);
 
+  if(!emm_ctx){
+    OAILOG_ERROR( LOG_NAS_EMM, "EMM-PROC  - No EMM context could be established for UE " MME_UE_S1AP_ID_FMT". \n", ue_idP);
+    OAILOG_FUNC_OUT(LOG_NAS);
+  }
+
   message_p = itti_alloc_new_message(TASK_NAS_EMM, NAS_CONNECTION_ESTABLISHMENT_CNF);
 
   NAS_CONNECTION_ESTABLISHMENT_CNF(message_p).ue_id                           = ue_idP;


### PR DESCRIPTION
S10 Procedures where not properly removed from UE context due false flag. Could have caused a crash with idle tau following an unsuccessfull s10 handover