### PR TITLE
Cassandra fails to build -> fix

### DIFF
--- a/build/tools/build_helper.cassandra
+++ b/build/tools/build_helper.cassandra
@@ -54,14 +54,14 @@ check_install_cassandra_software() {
     fi
     echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | $SUDO /usr/bin/debconf-set-selections
     # install Java 8
-    $SUDO $INSTALLER install $OPTION curl oracle-java8-installer
+    $SUDO $INSTALLER install $OPTION curl openjdk-8-jre
     if [ $PROXY_DISABLED -eq 1 ]
     then
         $SUDO mv /tmp/01proxy /etc/apt/apt.conf.d
     fi
 
     echo "deb http://www.apache.org/dist/cassandra/debian 21x main" | $SUDO  tee -a /etc/apt/sources.list.d/cassandra.sources.list
-    curl https://www.apache.org/dist/cassandra/KEYS | $SUDO  apt-key add -
+    curl https://downloads.apache.org/cassandra/KEYS | $SUDO  apt-key add -
     ret=$?;[[ $ret -ne 0 ]] && return $ret
     $SUDO apt-get update
     ret=$?;[[ $ret -ne 0 ]] && return $ret


### PR DESCRIPTION
Cassandra fails to build using "build_cassandra" (which calls "build/tools/build_helper.cassandra"):
* https://www.apache.org/dist/cassandra/KEYS is now a redirect to https://downloads.apache.org/cassandra/KEYS. The script did not handle the redirect, delivering nothing to apt-key => key installation failed. Fixed by updating the URL.
* oracle-java8-installer is discontinued. Fixed by using "openjdk-8-jre" instead.
